### PR TITLE
Set SHELL used by JupyterLab

### DIFF
--- a/etc/supervisord.d/jupyterlab.conf
+++ b/etc/supervisord.d/jupyterlab.conf
@@ -1,6 +1,6 @@
 [program:jupyterlab]
 command=bash -l -c "/opt/python/bin/jupyter lab --no-browser"
-environment=HOME=/home/researcher,USER=researcher,DISPLAY=:99
+environment=HOME=/home/researcher,USER=researcher,SHELL=/bin/bash,DISPLAY=:99
 directory=/home/researcher
 autorestart=true
 stdout_logfile=/var/log/supervisor/jupyterlab.log


### PR DESCRIPTION
Full commit message:

```
Default to bash shell.

See https://github.com/jupyter/jupyterlab/issues/489.
If SHELL is not defined, JupyterLab defaults to /bin/sh.
This is not desirable since we would like people to be able to do
things like customise their .bashrc and have JLab immediately
reflect those changes.
```
